### PR TITLE
initial checkin of extra volumes, volumeMounts, environment variables…

### DIFF
--- a/templates/taiga-back-statefulset.yaml
+++ b/templates/taiga-back-statefulset.yaml
@@ -34,6 +34,19 @@ spec:
             {{- toYaml .Values.taigaBack.securityContext | nindent 12 }}
           image: "{{ .Values.taigaBack.image.repository }}:{{ .Values.taigaBack.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.taigaBack.image.pullPolicy }}
+          lifecycle:
+          {{-   if .Values.taigaBack.lifecycle.postStartCommand }}
+            postStart:
+              exec:
+                command:
+                  {{- toYaml .Values.taigaBack.lifecycle.postStartCommand | nindent 18 -}}
+          {{-   end }}
+          {{-   if .Values.taigaBack.lifecycle.preStopCommand }}
+            preStop:
+              exec:
+                command:
+                  {{- toYaml .Values.taigaBack.lifecycle.preStopCommand | nindent 18 -}}
+          {{-   end }}
           ports:
             - name: http
               containerPort: 8000
@@ -64,7 +77,11 @@ spec:
             {{- end }}
 
             - name: PUBLIC_REGISTER_ENABLED
-              value: {{ lower .Values.env.publicRegisterEnabled | quote }}
+            {{- if eq (lower .Values.env.publicRegisterEnabled) "true" }}
+              value: "True"
+            {{- else }}
+              value: "True"
+            {{- end }}
 
             - name: ENABLE_SLACK
               value: {{ lower .Values.env.enableSlack | quote }}
@@ -155,11 +172,17 @@ spec:
             - name: TRELLO_IMPORTER_SECRET_KEY
               value: {{ .Values.env.trelloImporterSecretKey | quote }}
             {{- end }}
+            {{- if .Values.taigaBack.extraEnv }}
+{{ toYaml .Values.taigaBack.extraEnv | indent 12 }}
+            {{- end }}
           volumeMounts:
             - mountPath: /taiga-back/static
               name: taiga-static-data
             - mountPath: /taiga-back/media
               name: taiga-media-data
+            {{- if .Values.taigaBack.extraVolumeMounts }}
+{{ toYaml .Values.taigaBack.extraVolumeMounts | indent 12 }}
+            {{- end }}
           {{- with .Values.taigaBack.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
@@ -184,3 +207,6 @@ spec:
         - name: taiga-media-data
           persistentVolumeClaim:
             claimName: {{ include "taiga.fullname" . }}-media-data
+        {{- if .Values.taigaBack.extraVolumes }}
+{{ toYaml .Values.taigaBack.extraVolumes | indent 8 }}
+        {{- end }}

--- a/templates/taiga-front-statefulset.yaml
+++ b/templates/taiga-front-statefulset.yaml
@@ -79,6 +79,9 @@ spec:
             - name: ENABLE_TRELLO_IMPORTER
               value: {{ lower .Values.env.enableTrelloImporter | quote }}
             {{- end }}
+            {{- if .Values.taigaFront.extraEnv }}
+{{ toYaml .Values.taigaFront.extraEnv | indent 12 }}
+            {{- end }}
           {{- with .Values.taigaFront.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/values.yaml
+++ b/values.yaml
@@ -190,6 +190,38 @@ taigaBack:
 
   affinity: {}
 
+  # Extra environment variables
+  extraEnv: []
+  #- name: SOME_PLUGIN_RELATED_ENV
+  #  value: "True"
+  #- name: SOME_SECRET_ENV
+  #  valueFrom:
+  #    secretKeyRef:
+  #      name: secret_name
+  #      key: secret_key
+
+  # Allow configuration of lifecycle hooks
+  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/
+  lifecycle: {}
+  # postStartCommand: []
+  # - /bin/sh
+  # - -c
+  # - "cat /tmp/ca/ca.crt >> /opt/venv/lib/python3.7/site-packages/certifi/cacert.pem"
+  # preStopCommand: []
+
+  # Extra mounts for the pod. Useful for adding an onprem ca chain which can then be imported via a postStart command.
+  # kubectl create configmap ca-certs --from-file=ca.crt=/pathto/ca.crt
+  extraVolumes: []
+  #- name: certs
+  #  configMap:
+  #    name: ca-certs
+  #    items:
+  #    - key: "ca.crt"
+  #      path: "ca.crt"
+  extraVolumeMounts: []
+  #- name: certs
+  #  mountPath: /tmp/ca
+
 
 taigaDB:
 


### PR DESCRIPTION
These changes work for me to setup a mount with an onprem ca certificate chain in a configmap and then import that using a postStart command.  The ability to set an environment variable on the front and back stateful sets was also necessary to setup the environment variables needed by the https://github.com/robrotheram/taiga-contrib-openid-auth extension/plugin.

Notes:
1. The code was copy/pasted from nextcloud (and had the nindent values adjusted) and uses its naming method of 'extraVolumes', 'extraVolumeMounts', and 'extraEnv', however with the way you have things separated out I could have just used 'volumes', 'volumeMounts', and 'env' underneath taigaBack and taigaFront, let me know if you would prefer this.
2. Something is up with the publicRegisterEnabled  variable in the taigaBack stateful set.  When I set this at the top level it works for the front statefulset but not the back statefulset.  I had to hardcode it using a capital T as seen below.
3. I had to add PUBLIC_REGISTER_ENABLED as a variable in the front statefulset, I can see it is in the template but it doesn't get added unless I specify it.

My values.yaml file:
```
env:
  publicRegisterEnabled: "true"

taigaFront:
  image:
    repository: robrotheram/taiga-front-openid
    pullPolicy: IfNotPresent
    #pullPolicy: Always
    tag: 6.4.2
    #tag: latest
  extraEnv:
  - name: ENABLE_OPENID
    value: "true"
  - name: PUBLIC_REGISTER_ENABLED
    value: "true"
  - name: OPENID_URL
    value: "https://keycloak.k-prod.harmony.net/auth/realms/harmony/protocol/openid-connect/auth"
  - name: OPENID_CLIENT_ID
    value: "taiga.k-dev.harmony.net"
  - name: OPENID_NAME
    value: "keycloak"
  - name: OPENID_SCOPE
    value: "openid email"

taigaBack:
  image:
    repository: robrotheram/taiga-back-openid
    pullPolicy: IfNotPresent
    #pullPolicy: Always
    tag: 6.4.2
    #tag: latest
  extraEnv:
  - name: ENABLE_OPENID
    value: "True"
  #- name: PUBLIC_REGISTER_ENABLED
  #  value: "True"
  - name: OPENID_USER_URL
    value: "https://keycloak.k-prod.harmony.net/auth/realms/harmony/protocol/openid-connect/userinfo"
  - name: OPENID_TOKEN_URL
    value: "https://keycloak.k-prod.harmony.net/auth/realms/harmony/protocol/openid-connect/token"
  - name: OPENID_CLIENT_ID
    value: "taiga.k-dev.harmony.net"
  - name: OPENID_CLIENT_SECRET
    value: "<hidden>"
  - name: OPENID_SCOPE
    value: "openid email"
  extraVolumeMounts:
  - mountPath: /tmp/ca
    name: certs
  extraVolumes:
  - name: certs
    configMap:
      name: ca-certs
      items:
      - key: "ca.crt"
        path: "ca.crt"
  lifecycle:
    postStartCommand:
    - /bin/sh
    - -c
    - "cat /tmp/ca/ca.crt >> /opt/venv/lib/python3.7/site-packages/certifi/cacert.pem"


taigaAsync:
  image:
    tag: 6.4.2
#taigaFront:
#  image:
#    tag: 6.4.2
#taigaBack:
#  image:
#    tag: 6.4.2
taigaProtected:
  image:
    tag: 6.4.0
  name: taiga

env: 
  taigaURL: "https://taiga.k-dev.harmony.net"
  postgresHost: "taiga-db"

persistence:
  media:
    ## Volume used to store the Taiga Gateway's data. Default is boolean `false`.
    ##
    enabled: true
    size: '100Mi'
    ## Sets persistent volume claim's storageClassName. Defaults to `default`.
    ##
    storageClassName: longhorn-slow
    accessMode: 'ReadWriteMany'
  static:
    ## Volume used to store the Taiga Gateway's data. Default is boolean `false`.
    ##
    enabled: true
    size: '100Mi'
    ## Sets persistent volume claim's storageClassName. Defaults to `default`.
    ##
    storageClassName: longhorn-slow
    accessMode: 'ReadWriteMany'
```