### PR TITLE
fix letter case of EMAIL_BACKEND

### DIFF
--- a/templates/taiga-back-statefulset.yaml
+++ b/templates/taiga-back-statefulset.yaml
@@ -89,7 +89,7 @@ spec:
 
             {{- if eq (lower .Values.env.enableEmail) "true" }}
             - name: EMAIL_BACKEND
-              value: {{ lower .Values.env.emailBackend | quote }}
+              value: {{ .Values.env.emailBackend | quote }}
             - name: DEFAULT_FROM_EMAIL
               value: {{ .Values.env.defaultFromEmail | quote }}
             - name: EMAIL_HOST


### PR DESCRIPTION
**Current behaviour:**

For the default setting of `emailBackend: "django.core.mail.backends.smtp.EmailBackend"` in `values.yaml`, pod taiga-back fails on sending emails with:

```
ImportError: Module "django.core.mail.backends.smtp" does not define a "emailbackend" attribute/class
```

**Expected behaviour:**

Emails are sent properly for that default configuration.

**Cause of the error:**

Env var `EMAIL_BACKEND` in that pod is set to `django.core.mail.backends.smtp.emailbackend` that is incorrect for Django.

**Solution:**

Remove `lower` for `EMAIL_BACKEND` in the template of sts/taiga-back.