### PR TITLE
Added Value to enable or disable gravatar integration

### DIFF
--- a/templates/taiga-front-configmap.yaml
+++ b/templates/taiga-front-configmap.yaml
@@ -32,6 +32,6 @@ data:
         "enableGithubImporter": ${ENABLE_GITHUB_IMPORTER},
         "enableJiraImporter": ${ENABLE_JIRA_IMPORTER},
         "enableTrelloImporter": ${ENABLE_TRELLO_IMPORTER},
-        "gravatar": false,
+        "gravatar": ${ENABLE_GRAVATAR},
         "rtlLanguages": ["fa"]
     }

--- a/templates/taiga-front-statefulset.yaml
+++ b/templates/taiga-front-statefulset.yaml
@@ -79,6 +79,10 @@ spec:
             - name: ENABLE_TRELLO_IMPORTER
               value: {{ lower .Values.env.enableTrelloImporter | quote }}
             {{- end }}
+
+            - name: ENABLE_GRAVATAR
+              value: {{ lower .Values.env.enableGravatar | quote }}
+
           {{- with .Values.taigaFront.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/values.yaml
+++ b/values.yaml
@@ -82,6 +82,8 @@ env:
 
   maxAge: "360"
 
+  enableGravatar: "false"
+
 taigaAsyncRabbitmq:
 
   image:


### PR DESCRIPTION
By default Gravatar stays disabled, but:
- Added Value env.enableGravatar (possible values, "true", "false", default: "false") to enable or disable the Gravatar integration